### PR TITLE
feat: sort roster by position and clarify team strengths

### DIFF
--- a/frontend/fantasy-helper-ui/src/components/TableCard.tsx
+++ b/frontend/fantasy-helper-ui/src/components/TableCard.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 
 interface TableCardProps {
   title: string;
-  headers: string[];
+  headers: ReactNode[];
   children: ReactNode;
 }
 
@@ -16,8 +16,8 @@ export default function TableCard({ title, headers, children }: TableCardProps) 
       <Table stickyHeader hoverRow>
         <thead>
           <tr>
-            {headers.map((h) => (
-              <th key={h}>{h}</th>
+            {headers.map((h, i) => (
+              <th key={i}>{h}</th>
             ))}
           </tr>
         </thead>


### PR DESCRIPTION
## Summary
- allow roster table to be sorted by position via interactive header
- expand team comparison strength/weakness with average tier context
- support ReactNode headers in `TableCard` for interactive column titles

## Testing
- `npm test` (fails: missing script)
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1b14540388327ae2384dba08c44bf